### PR TITLE
We let the thread finish before stopping it, by calling waitForThread().

### DIFF
--- a/libs/ofxSMTP/src/Client.cpp
+++ b/libs/ofxSMTP/src/Client.cpp
@@ -40,12 +40,7 @@ Client::Client():
 Client::~Client()
 {
     _messageReady.set();
-
-    if (getPocoThread().isRunning())
-    {
-        stopThread();
-        getPocoThread().join(); // force the join
-    }
+    waitForThread();
 }
 
 


### PR DESCRIPTION
This prevent the application to crash when quitting, on OS X. It does not solve the issue on Windows though.
