### PR TITLE
Added login call when login method = AUTH_NONE

### DIFF
--- a/libs/ofxSMTP/src/Client.cpp
+++ b/libs/ofxSMTP/src/Client.cpp
@@ -173,6 +173,11 @@ void Client::threadedFunction()
                               _settings.getCredentials().getUsername(),
                               _settings.getCredentials().getPassword());
             }
+            else
+            {
+                //this will simply send a helo to the server, required in some circumstances
+                session.login();
+            }
 
             while (getOutboxSize() > 0 && isThreadRunning())
             {


### PR DESCRIPTION
When using this addon in a recent install we discovered sending would fail if a 'helo' was not sent before sending was attempted.  In this case we were connecting to a SMTP relay server where authentication was not required.  Adding a simple login call fixes the issue.
